### PR TITLE
Add env var checks

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,16 @@ load_dotenv()
 MCP_URL = os.getenv("MCP_SERVER_URL")
 API_KEY = os.getenv("OPENAI_API_KEY")
 
+missing = []
+if not MCP_URL:
+    missing.append("MCP_SERVER_URL")
+if not API_KEY:
+    missing.append("OPENAI_API_KEY")
+if missing:
+    raise EnvironmentError(
+        f"Missing required environment variables: {', '.join(missing)}"
+    )
+
 openai_client = openai.OpenAI(api_key=API_KEY)
 
 app = FastAPI()


### PR DESCRIPTION
## Summary
- check for `MCP_SERVER_URL` and `OPENAI_API_KEY` when starting the API server

## Testing
- `python -m py_compile main.py`
- `python -m py_compile mcp_demo/mcp_server.py mcp_demo/tools/time_tool.py`


------
https://chatgpt.com/codex/tasks/task_e_684951f171448328a53665f9e537c815